### PR TITLE
feat(api/docs): add GET /dc/:id

### DIFF
--- a/apps/jsonthing-api/src/routes/docs/controllers/docs-aliases.controller.spec.ts
+++ b/apps/jsonthing-api/src/routes/docs/controllers/docs-aliases.controller.spec.ts
@@ -1,0 +1,81 @@
+import { DocsAliasesController } from '@/routes/docs/controllers/docs-aliases.controller'
+import { DocsService } from '@/routes/docs/service'
+import { Test, TestingModule } from '@nestjs/testing'
+import mongoose from 'mongoose'
+
+const ObjectId = mongoose.Types.ObjectId
+
+jest.mock('../service')
+
+const testingModuleMetadata = {
+    controllers: [DocsAliasesController],
+    providers: [
+        {
+            provide: DocsService,
+            useClass: DocsService,
+        },
+    ],
+}
+
+describe('docsAliasesController', () => {
+    let testingModule: TestingModule
+    let docsService: jest.Mocked<DocsService>
+    let docsAliasesController: DocsAliasesController
+
+    beforeAll(async () => {
+        testingModule = await Test.createTestingModule(
+            testingModuleMetadata,
+        ).compile()
+
+        docsService = testingModule.get(DocsService)
+
+        docsAliasesController = testingModule.get(
+            DocsAliasesController,
+        )
+    })
+
+    afterAll(() => {
+        testingModule.close()
+    })
+
+    describe('getDocContent', () => {
+        it('should use docsService.getDocById', async () => {
+            expect.assertions(1)
+
+            const docId = new ObjectId()
+
+            // @ts-expect-error: just a mock
+            docsService.getDocById.mockResolvedValueOnce({})
+
+            await docsAliasesController.getDocContent(
+                docId.toString(),
+            )
+
+            expect(
+                docsService.getDocById,
+            ).toHaveBeenCalledExactlyOnceWith(docId)
+        })
+    })
+
+    it(`should return docsService.getDocById's result.content`, async () => {
+        expect.assertions(1)
+
+        const docId = new ObjectId()
+
+        const getDocByIdResult = {
+            id: docId.toString(),
+            title: 'Title',
+            content: {
+                value: 'doc-content',
+            },
+        }
+
+        docsService.getDocById.mockResolvedValueOnce(getDocByIdResult)
+
+        const result = await docsAliasesController.getDocContent(
+            docId.toString(),
+        )
+
+        expect(result).toStrictEqual(getDocByIdResult.content)
+    })
+})

--- a/apps/jsonthing-api/src/routes/docs/controllers/docs-aliases.controller.ts
+++ b/apps/jsonthing-api/src/routes/docs/controllers/docs-aliases.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param } from '@nestjs/common'
+import mongoose from 'mongoose'
+import { DocsService } from '../service'
+
+@Controller('dc')
+export class DocsAliasesController {
+    constructor(private readonly docsService: DocsService) {}
+
+    @Get(':id')
+    getDocContent(@Param('id') docId: string): object {
+        const queryId = new mongoose.Types.ObjectId(docId)
+
+        return this.docsService
+            .getDocById(queryId)
+            .then(doc => doc.content)
+    }
+}

--- a/apps/jsonthing-api/src/routes/docs/controllers/index.ts
+++ b/apps/jsonthing-api/src/routes/docs/controllers/index.ts
@@ -1,1 +1,2 @@
+export * from './docs-aliases.controller'
 export * from './docs.controller'

--- a/apps/jsonthing-api/src/routes/docs/docs.module.spec.ts
+++ b/apps/jsonthing-api/src/routes/docs/docs.module.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { DocsModule } from '.'
-import { DocsController } from './controllers'
+import { DocsAliasesController, DocsController } from './controllers'
 import { DocsModelModule } from './model'
 import { DocsService } from './service'
 
@@ -35,6 +35,16 @@ describe('docsModule', () => {
         const docsController = docsTestingModule.get(DocsController)
 
         expect(docsController).toBeDefined()
+    })
+
+    it('should have DocsAliasesController', () => {
+        expect.assertions(1)
+
+        const docsAliasesController = docsTestingModule.get(
+            DocsAliasesController,
+        )
+
+        expect(docsAliasesController).toBeDefined()
     })
 
     it('should have DocsService', () => {

--- a/apps/jsonthing-api/src/routes/docs/docs.module.ts
+++ b/apps/jsonthing-api/src/routes/docs/docs.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common'
-import { DocsController } from './controllers'
+import { DocsAliasesController, DocsController } from './controllers'
 import { DocsModelModule } from './model'
 import { DocsService } from './service'
 
 @Module({
     imports: [DocsModelModule],
-    controllers: [DocsController],
+    controllers: [DocsController, DocsAliasesController],
     providers: [DocsService],
 })
 export class DocsModule {}


### PR DESCRIPTION
Add alias endpoint for `GET /docs/:id/content` (#56)